### PR TITLE
show greyed out shield icon for non-Ctemplar users and show solid col…

### DIFF
--- a/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.html
+++ b/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.html
@@ -241,7 +241,7 @@
         </td>
 
         <!-- Icon Secured -->
-        <td class="mail-security-status">
+        <td class="mail-security-status" [ngClass]="{'text-faded': !mail.is_encrypted}">
           <i class="icon icon-secured"></i>
         </td>
 


### PR DESCRIPTION
1. When an email is sent to NON-Ctemplar users only THEN grey out the “Shield with lock Icon”
2. When an email is sent to Both Ctemplar AND non-ctemplar users then shield icon with lock is solid color.
3. When an email is sent to only ctemplar users then shield icon with lock is also solid color.