### PR TITLE
Bugfix/feedback 2018081401

### DIFF
--- a/src/app/mail/mail-settings/mail-settings.component.html
+++ b/src/app/mail/mail-settings/mail-settings.component.html
@@ -27,8 +27,9 @@
                                         <div class="info-list-text info-list-label" translate="settings.domains">
                                             Domains
                                         </div>
-                                        <div class="info-list-text info-list-val"
-                                             translate="settings.feature_coming_soon">Feature coming soon!
+                                        <div class="info-list-text info-list-val">
+                                             <span *ngIf="userState.isPrime" translate="settings.feature_coming_soon">Feature coming soon!</span>
+                                             <span *ngIf="!userState.isPrime" translate="settings.none">None</span>
                                         </div>
                                     </li>
                                     <li class="info-list-item align-items-start">
@@ -36,13 +37,18 @@
                                             Addresses
                                         </div>
                                         <div class="info-list-text info-list-val">
-                                            <div class="ng-tooltips-holder d-inline-block" placement="top"
-                                                 ngbTooltip="Prime accounts will be credited with 4 additional addresses at no cost as soon as this function is available">
-                                                <div class="info-list-val-text" translate="settings.address_tooltip">One
-                                                    - More available soon!
-                                                </div>
-
+                                            <div *ngIf="userState.isPrime" class="ng-tooltips-holder d-inline-block" placement="top"
+                                                  ngbTooltip="Prime accounts will be credited with 2 additional addresses at no cost as soon as this function is available">
+                                               <div class="info-list-val-text" translate="settings.address_tooltip">
+                                                   One - More available soon!
+                                               </div>
                                             </div>
+                                            <div *ngIf="!userState.isPrime"  class="d-inline-block">
+                                                <div class="info-list-val-text" translate="settings.address_one">
+                                                    One
+                                                </div>
+                                            </div>
+                                           
                                         </div>
                                     </li>
                                     <li class="info-list-item">

--- a/src/app/mail/mail-settings/mail-settings.component.html
+++ b/src/app/mail/mail-settings/mail-settings.component.html
@@ -714,11 +714,6 @@
         </header>
         <div class="mailbox-section-body mailbox-section-body-sm">
             <div class="form-content-holder">
-                <div class="info-card">
-                    <p translate="settings.keys.info">Download your PGP Keys for use with other PGP compatible services. Only incoming messages in
-                        inline OpenPGP format are currently supported.</p>
-                </div>
-
                 <div class="form-content-row">
                     <div class="row align-items-center">
                         <div class="col-sm-5">

--- a/src/app/shared/components/pricing-plans/pricing-plans.component.html
+++ b/src/app/shared/components/pricing-plans/pricing-plans.component.html
@@ -54,16 +54,16 @@
                     <i class="fa fa-check text-green"></i>Normal Support
                   </li>
                   <li class="package-list-item">
-                    <i class="fa fa-check text-green"></i>Dead Mans Timer
-                  </li>
-                  <li class="package-list-item">
-                    <i class="fa fa-check text-green"></i>Delayed Delivery Timer
-                  </li>
-                  <li class="package-list-item">
                     <i class="fa fa-check text-green"></i>Self Destruct Timer
                   </li>
                   <li class="package-list-item">
                     <i class="fa fa-check text-green"></i>Encryption for non-CTemplar Users
+                  </li>
+                  <li class="package-list-item">
+                    <i class="fa fa-check text-green"></i>Dead Mans Timer
+                  </li>
+                  <li class="package-list-item">
+                    <i class="fa fa-check text-green"></i>Delayed Delivery Timer
                   </li>
                 </ul>
                 <div class="package-coming-soon mt-3">
@@ -202,20 +202,20 @@
                     <i class="fa fa-check text-green"></i>Limited Support
                   </li>
                   <li class="package-list-item">
+                    <i class="fa fa-check text-green"></i>
+                    Self Destruct Timer
+                  </li>
+                  <li class="package-list-item">
+                    <i class="fa fa-check text-green"></i>
+                    Encryption for non-CTemplar Users
+                  </li>
+                  <li class="package-list-item">
                     <i class="fa fa-times text-danger"></i>
                     <del>Dead Mans Timer</del>
                   </li>
                   <li class="package-list-item">
                     <i class="fa fa-times text-danger"></i>
                     <del>Delayed Delivery Timer</del>
-                  </li>
-                  <li class="package-list-item">
-                    <i class="fa fa-times text-danger"></i>
-                    <del>Self Destruct Timer</del>
-                  </li>
-                  <li class="package-list-item">
-                    <i class="fa fa-times text-danger"></i>
-                    <del>Encryption for non-CTemplar Users</del>
                   </li>
                 </ul>
               </div>

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -45,6 +45,8 @@
     "domains": "المجالات",
     "feature_coming_soon": " ميزة ستضاف قريباً!",
     "addresses": "العناوين",
+    "address_one": "واحد",
+    "none": "لا شيء",
     "storage": "التخزين",
     "address_tooltip": " واحد - ستضاف قريباً!",
     "my_subscription": "اشتراكي",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -47,6 +47,8 @@
     "addresses": "Addresses",
     "storage": "Storage",
     "address_tooltip": "One - More available soon!",
+    "address_one": "One",
+    "none": "None",
     "my_subscription": "My Subscription",
     "plans": "Plans",
     "prime_plan": "Prime Plan",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -45,6 +45,8 @@
     "domains": "Dominios",
     "feature_coming_soon": "¡Próximamente esta característica!",
     "addresses": "Direcciones",
+    "address_one": "Uno",
+    "none": "Ninguna",
     "storage": "Almacenamiento",
     "address_tooltip": "Una - ¡Más disponibles próximamente!",
     "my_subscription": "Mi suscripción ",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -45,6 +45,8 @@
     "domains": "Domaines",
     "feature_coming_soon": "Feature à venir bientôt!",
     "addresses": "Adresses",
+    "address_one": "Un",
+    "none": "Aucun",
     "storage": "Espace de rangement",
     "address_tooltip": "One - Plus disponible bientôt!",
     "my_subscription": "Mon abonnement",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -45,6 +45,8 @@
     "domains": "דומיינים",
     "feature_coming_soon": "תכונה בקרוב!",
     "addresses": "כתובות",
+    "address_one": "אחד",
+    "none": "אף אחד",
     "storage": "אִחסוּן",
     "address_tooltip": "אחת - זמין בקרוב!",
     "my_subscription": "המנוי שלי",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -45,6 +45,8 @@
     "domains": "Lén",
     "feature_coming_soon": "Lögun kemur fljótlega!",
     "addresses": "Heimilisföng",
+    "address_one": "Einn",
+    "none": "Enginn",
     "storage": "Geymsla",
     "address_tooltip": "Einn - Meira í boði fljótlega!",
     "my_subscription": "Áskrift mín",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -45,6 +45,8 @@
     "domains": "domini",
     "feature_coming_soon": "Funzionalità in arrivo!",
     "addresses": "indirizzi",
+    "address_one": "Uno",
+    "none": "Nessuna",
     "storage": "Conservazione",
     "address_tooltip": "Uno - Più disponibili a breve!",
     "my_subscription": "La mia iscrizione",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -45,6 +45,8 @@
     "domains": "Domeinen",
     "feature_coming_soon": "Functies binnenkort beschikbaar!",
     "addresses": "Adressen",
+    "address_one": "een",
+    "none": "Geen",
     "storage": "Opslagruimte",
     "address_tooltip": "Een – Binnenkort meer beschikbaar!",
     "my_subscription": "Mijn abonnement",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -45,6 +45,8 @@
     "domains": "Domínios",
     "feature_coming_soon": "Recurso disponível em breve!",
     "addresses": "Endereços",
+    "address_one": "um",
+    "none": "Nenhum",
     "storage": "Armazenamento",
     "address_tooltip": "Um – Mais estará disponível em breve!",
     "my_subscription": "Meu plano",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -45,6 +45,8 @@
     "domains": "Домены",
     "feature_coming_soon": "Функция скоро появится!",
     "addresses": "Адреса",
+    "address_one": "Один",
+    "none": "Никто",
     "storage": "Место хранения",
     "address_tooltip": "Один - более скоро!",
     "my_subscription": "Моя подписка",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -45,6 +45,8 @@
     "domains": "Домени",
     "feature_coming_soon": "Особливість незабаром!",
     "addresses": "Адреси",
+    "address_one": "Один",
+    "none": "Ні",
     "storage": "Зберігання",
     "address_tooltip": "Один - доступно найближчим часом!",
     "my_subscription": "Моя підписка",

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -45,6 +45,8 @@
     "domains": "域名",
     "feature_coming_soon": "此功能即将推出！",
     "addresses": "通信地址",
+    "address_one": "壹",
+    "none": "没有",
     "storage": "存储空间",
     "address_tooltip": "敬请期待!",
     "my_subscription": "我的订阅",


### PR DESCRIPTION
- delete text on settings page for `Download your PGP keys....`
- change tooltip on dashboard and translations for the new text
- add self destruct and encryption for non-ctemplar users to free signup