### PR TITLE
downgrade to 4.10.4 for openpgp library

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "moment-timezone": "^0.5.27",
     "ngx-chips": "^2.1.0",
     "ngx-quill": "^8.0.0",
-    "openpgp": "^4.10.8",
+    "openpgp": "^4.10.4",
     "quill": "^1.3.7",
     "quill-image-resize-module": "^3.0.0",
     "raven-js": "^3.27.2",


### PR DESCRIPTION
This PR needs downtime.
Not sure this would apply on the server automatically, at least I did it on my local manually.
- Remove origin openpgp-4.10.8, run `npm install`
- Add openpgp-4.10.4, run `npm install`

