### PR TITLE
DEV-2089, DEV-1943, DEV-2059, DEV-2060

### DIFF
--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.ts
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.ts
@@ -948,7 +948,9 @@ export class ComposeMailComponent implements OnInit, AfterViewInit, OnChanges, O
           debounceTime(Number(this.settings.autosave_duration)), // get autosave interval from user's settings
         )
         .subscribe(data => {
-          this.updateEmail();
+          if (!this.draft.isSaving) {
+            this.updateEmail();
+          }
         });
     }
   }
@@ -991,7 +993,7 @@ export class ComposeMailComponent implements OnInit, AfterViewInit, OnChanges, O
 
   onFilesSelected(files: FileList) {
     this.isProcessingAttachments = true;
-    if (!this.draftMail || !this.draftMail.id) {
+    if ((!this.draftMail || !this.draftMail.id) && !this.draft.isSaving) {
       this.updateEmail();
     }
     for (let i = 0; i < files.length; i++) {

--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.ts
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.ts
@@ -1016,6 +1016,7 @@ export class ComposeMailComponent implements OnInit, AfterViewInit, OnChanges, O
         is_inline: isInline,
         is_encrypted: !isInline,
         inProgress: false,
+        actual_size: file.size,
       };
       this.attachments.push(attachment);
       if (!this.draftMail.id) {

--- a/src/app/store/models/mail.model.ts
+++ b/src/app/store/models/mail.model.ts
@@ -126,6 +126,7 @@ export interface Attachment {
   progress?: number;
   request?: Subscription;
   size: string;
+  actual_size?: number;
 }
 
 export interface EmailDisplay {

--- a/src/app/store/services/mail.service.ts
+++ b/src/app/store/services/mail.service.ts
@@ -180,6 +180,7 @@ export class MailService {
     formData.append('is_encrypted', attachment.is_encrypted.toString());
     formData.append('file_type', attachment.document.type.toString());
     formData.append('name', attachment.name.toString());
+    formData.append('actual_size', attachment.actual_size.toString());
     let request;
     if (attachment.id) {
       request = new HttpRequest('PATCH', `${apiUrl}emails/attachments/update/${attachment.id}/`, formData, {


### PR DESCRIPTION
Fixes #DEV-2089, DEV-1943, DEV-2059, DEV-2060

### Changes description
This PR contains 2 updates essentially
  -  `actual_size` key was added on the file uploading payload. it would be used for calculating the size of the original file before encrypted. The backend should take this value instead the document's real size and decide to raise the error or not.
  -  There was an bug to call post double in email composing service, if we are trying to upload the file before creating the draft instance.