### PR TITLE
Add a setting to display plain text messages by default

### DIFF
--- a/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.ts
+++ b/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.ts
@@ -96,9 +96,14 @@ export class MailDetailBodyComponent implements OnInit, OnChanges {
   checkedShowPlainTextSetting = false;
 
   constructor(private store: Store<AppState>) {}
-  
+
   ngOnChanges(changes: SimpleChanges): void {
-    if(this.decryptedContentsPlain && this.settings.show_plain_text && !this.plainTextViewState && !this.checkedShowPlainTextSetting ) {
+    if (
+      this.decryptedContentsPlain &&
+      this.settings.show_plain_text &&
+      !this.plainTextViewState &&
+      !this.checkedShowPlainTextSetting
+    ) {
       this.checkedShowPlainTextSetting = true;
       this.onSwitchHtmlPlainTextMode.emit();
     }

--- a/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.ts
+++ b/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.ts
@@ -1,7 +1,7 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { Attachment, Mail, MailFolderType } from '../../../store/models';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { AppState, UserState } from '../../../store/datatypes';
+import { AppState, Settings, UserState } from '../../../store/datatypes';
 import { Store } from '@ngrx/store';
 import { LOADING_IMAGE } from '../../../store/services';
 
@@ -11,7 +11,7 @@ import { LOADING_IMAGE } from '../../../store/services';
   templateUrl: './mail-detail-body.component.html',
   styleUrls: ['./mail-detail-body.component.scss'],
 })
-export class MailDetailBodyComponent implements OnInit {
+export class MailDetailBodyComponent implements OnInit, OnChanges {
   /**
    * Input Section
    */
@@ -91,7 +91,25 @@ export class MailDetailBodyComponent implements OnInit {
 
   loadingImage = LOADING_IMAGE;
 
-  constructor(private store: Store<AppState>) {}
+  settings: Settings;
 
-  ngOnInit(): void {}
+  checkedShowPlainTextSetting = false;
+
+  constructor(private store: Store<AppState>) {}
+  
+  ngOnChanges(changes: SimpleChanges): void {
+    if(this.decryptedContentsPlain && this.settings.show_plain_text && !this.plainTextViewState && !this.checkedShowPlainTextSetting ) {
+      this.checkedShowPlainTextSetting = true;
+      this.onSwitchHtmlPlainTextMode.emit();
+    }
+  }
+
+  ngOnInit(): void {
+    this.store
+      .select((state: AppState) => state.user)
+      .pipe(untilDestroyed(this))
+      .subscribe((user: UserState) => {
+        this.settings = user.settings;
+      });
+  }
 }

--- a/src/app/mail/mail-settings/mail-settings.component.html
+++ b/src/app/mail/mail-settings/mail-settings.component.html
@@ -1070,6 +1070,43 @@
               <div class="form-content-row">
                 <div class="row align-items-center">
                   <div class="col-sm-3">
+                    <label class="form-label mb-0" [translate]="'mail_detail.show_plain_text'">Show Plain Text</label>
+                  </div>
+                  <div class="col-sm-7 col-md-5">
+                    <div class="row row-sm">
+                      <div class="col-6 flex-auto-col">
+                        <div class="fancy-field-group">
+                          <input
+                            class="d-none fancy-field-control fancy-field-control-sm"
+                            id="showPlainTextMode1"
+                            name="[showPlainTextMode]"
+                            type="radio"
+                            (click)="updateShowPlainTextMode(true)"
+                            [checked]="settings.is_conversation_mode"
+                          />
+                          <label for="showPlainTextMode1" [translate]="'common.enabled'">Enabled</label>
+                        </div>
+                      </div>
+                      <div class="col-6 flex-auto-col">
+                        <div class="fancy-field-group">
+                          <input
+                            class="d-none fancy-field-control fancy-field-control-sm"
+                            id="showPlainTextMode2"
+                            name="[showPlainTextMode]"
+                            type="radio"
+                            (click)="updateShowPlainTextMode(false)"
+                            [checked]="!settings.is_conversation_mode"
+                          />
+                          <label for="showPlainTextMode2" [translate]="'common.disabled'">Disabled</label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="form-content-row">
+                <div class="row align-items-center">
+                  <div class="col-sm-3">
                     <label for="customCss" class="form-label mb-sm-0"> Customize CSS </label>
                   </div>
                   <form class="col-sm-7 col-md-5" autocomplete="off">
@@ -1196,7 +1233,7 @@
                 <i class="fas fa-copy font-20px" ngbTooltip="Copy to clipboard"></i>
               </button>
             </div>
-            <div class="info-card mx-3 mt-2 full-width">
+            <div class="info-card mt-2 full-width">
               <p [translate]="'settings.get_one_month_prime_membership'">
                 Get one month of Prime membership free for every Prime sign up made using your referral code.
               </p>

--- a/src/app/mail/mail-settings/mail-settings.component.html
+++ b/src/app/mail/mail-settings/mail-settings.component.html
@@ -645,6 +645,43 @@
                   </div>
                 </div>
               </div>
+              <div class="form-content-row">
+                <div class="row align-items-center">
+                  <div class="col-sm-3">
+                    <label class="form-label mb-0" [translate]="'mail_detail.show_plain_text'">Show Plain Text</label>
+                  </div>
+                  <div class="col-sm-7 col-md-5">
+                    <div class="row row-sm">
+                      <div class="col-6 flex-auto-col">
+                        <div class="fancy-field-group">
+                          <input
+                            class="d-none fancy-field-control fancy-field-control-sm"
+                            id="showPlainTextMode1"
+                            name="[showPlainTextMode]"
+                            type="radio"
+                            (click)="updateShowPlainTextMode(true)"
+                            [checked]="settings.show_plain_text"
+                          />
+                          <label for="showPlainTextMode1" [translate]="'common.enabled'">Enabled</label>
+                        </div>
+                      </div>
+                      <div class="col-6 flex-auto-col">
+                        <div class="fancy-field-group">
+                          <input
+                            class="d-none fancy-field-control fancy-field-control-sm"
+                            id="showPlainTextMode2"
+                            name="[showPlainTextMode]"
+                            type="radio"
+                            (click)="updateShowPlainTextMode(false)"
+                            [checked]="!settings.show_plain_text"
+                          />
+                          <label for="showPlainTextMode2" [translate]="'common.disabled'">Disabled</label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </section>
@@ -1061,43 +1098,6 @@
                             [checked]="!settings.is_conversation_mode"
                           />
                           <label for="conversationViewMode2" [translate]="'common.disabled'">Disabled</label>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="form-content-row">
-                <div class="row align-items-center">
-                  <div class="col-sm-3">
-                    <label class="form-label mb-0" [translate]="'mail_detail.show_plain_text'">Show Plain Text</label>
-                  </div>
-                  <div class="col-sm-7 col-md-5">
-                    <div class="row row-sm">
-                      <div class="col-6 flex-auto-col">
-                        <div class="fancy-field-group">
-                          <input
-                            class="d-none fancy-field-control fancy-field-control-sm"
-                            id="showPlainTextMode1"
-                            name="[showPlainTextMode]"
-                            type="radio"
-                            (click)="updateShowPlainTextMode(true)"
-                            [checked]="settings.is_conversation_mode"
-                          />
-                          <label for="showPlainTextMode1" [translate]="'common.enabled'">Enabled</label>
-                        </div>
-                      </div>
-                      <div class="col-6 flex-auto-col">
-                        <div class="fancy-field-group">
-                          <input
-                            class="d-none fancy-field-control fancy-field-control-sm"
-                            id="showPlainTextMode2"
-                            name="[showPlainTextMode]"
-                            type="radio"
-                            (click)="updateShowPlainTextMode(false)"
-                            [checked]="!settings.is_conversation_mode"
-                          />
-                          <label for="showPlainTextMode2" [translate]="'common.disabled'">Disabled</label>
                         </div>
                       </div>
                     </div>

--- a/src/app/mail/mail-settings/mail-settings.component.ts
+++ b/src/app/mail/mail-settings/mail-settings.component.ts
@@ -391,7 +391,7 @@ export class MailSettingsComponent implements OnInit, AfterViewInit {
   }
 
   updateShowPlainTextMode(is_showplaintext_mode: boolean) {
-    // this.updateSettings('is_showplaintext_mode', is_showplaintext_mode);
+    this.updateSettings('show_plain_text', is_showplaintext_mode);
   }
 
   /**

--- a/src/app/mail/mail-settings/mail-settings.component.ts
+++ b/src/app/mail/mail-settings/mail-settings.component.ts
@@ -390,6 +390,10 @@ export class MailSettingsComponent implements OnInit, AfterViewInit {
     this.store.dispatch(new GetUnreadMailsCount());
   }
 
+  updateShowPlainTextMode(is_showplaintext_mode: boolean) {
+    // this.updateSettings('is_showplaintext_mode', is_showplaintext_mode);
+  }
+
   /**
    * convert m:s format to milliseconds and update settings
    */

--- a/src/app/store/datatypes.ts
+++ b/src/app/store/datatypes.ts
@@ -297,6 +297,8 @@ export class Settings {
   use_local_cache?: string;
 
   referral_code?: string;
+
+  show_plain_text?: boolean;
 }
 
 export interface Invoice {


### PR DESCRIPTION
Fixes #1198 

### Changes description

- Added `show_plain_text` field in settings. Default value is `false`.
- Implemented to display plain text messages by setting.
