### PR TITLE
Added back the "Ask to use local cache" on settings/security page

### DIFF
--- a/src/app/mail/mail-settings/security/security.component.html
+++ b/src/app/mail/mail-settings/security/security.component.html
@@ -186,6 +186,16 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+
+  <header class="ui-header ui-header-bordered">
+    <h5 class="ui-header-subtitle text-dark mb-0">
+      <strong [translate]="'settings.security.local_storage'">Local Storage</strong>
+    </h5>
+  </header>
+  <div class="mailbox-section-body mailbox-section-body-sm">
+    <div class="form-content-holder">
       <!-- Using Local Storage for Encryption Data -->
       <div class="form-content-row">
         <div class="row align-items-center">
@@ -220,6 +230,45 @@
                     [checked]="!isUsingLocalStorage"
                   />
                   <label for="usingLocalStorage2" [translate]="'common.disabled'">Disabled</label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="form-content-row">
+        <div class="row align-items-center">
+          <div class="col-sm-3">
+            <label class="form-label mb-0" [translate]="'settings.ask_local_cache'"
+              >Ask to use local cache</label
+            >
+          </div>
+          <div class="col-sm-7 col-md-5">
+            <div class="row row-sm">
+              <div class="col-6 flex-auto-col">
+                <div class="fancy-field-group">
+                  <input
+                    class="d-none fancy-field-control fancy-field-control-sm"
+                    id="askLocalCacheEnable"
+                    name="[askLocalCache]"
+                    type="radio"
+                    (click)="updateSettings('use_local_cache', 'ASK')"
+                    [checked]="askLocalCache"
+                  />
+                  <label for="askLocalCacheEnable" [translate]="'common.enabled'">Enabled</label>
+                </div>
+              </div>
+              <div class="col-6 flex-auto-col">
+                <div class="fancy-field-group">
+                  <input
+                    class="d-none fancy-field-control fancy-field-control-sm"
+                    id="askLocalCacheDisable"
+                    name="[askLocalCache]"
+                    type="radio"
+                    (click)="updateSettings('use_local_cache', 'DISALLOWED')"
+                    [checked]="!askLocalCache"
+                  />
+                  <label for="askLocalCacheDisable" [translate]="'common.disabled'">Disabled</label>
                 </div>
               </div>
             </div>

--- a/src/app/mail/mail-settings/security/security.component.html
+++ b/src/app/mail/mail-settings/security/security.component.html
@@ -239,9 +239,7 @@
       <div class="form-content-row">
         <div class="row align-items-center">
           <div class="col-sm-3">
-            <label class="form-label mb-0" [translate]="'settings.ask_local_cache'"
-              >Ask to use local cache</label
-            >
+            <label class="form-label mb-0" [translate]="'settings.ask_local_cache'">Ask to use local cache</label>
           </div>
           <div class="col-sm-7 col-md-5">
             <div class="row row-sm">

--- a/src/app/mail/mail-settings/security/security.component.ts
+++ b/src/app/mail/mail-settings/security/security.component.ts
@@ -70,6 +70,8 @@ export class SecurityComponent implements OnInit {
 
   passwordChangeInProgress = false;
 
+  askLocalCache: boolean;
+
   constructor(
     private store: Store<AppState>,
     private settingsService: MailSettingsService,
@@ -90,6 +92,7 @@ export class SecurityComponent implements OnInit {
         this.userState = user;
         this.isContactsEncrypted = user.settings.is_contacts_encrypted;
         this.settings$.next(user.settings);
+        this.askLocalCache = user.settings.use_local_cache && user.settings.use_local_cache === 'ASK';
       });
 
     /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -340,6 +340,7 @@
       "disable_2FA": "Disable 2 Factor authentication",
       "upgrade_to_paid": "Please upgrade to paid plan in order to use this feature",
       "contacts_encryption": "Contacts encryption",
+      "local_storage": "Local Storage",
       "using_local_storage": "Using local/session storage",
       "anti_phishing_phrase": "The Anti-Phishing phrase allows users to link a custom word or phrase of your choice to your CTemplar account.Once set, if you ever log into your webmail and your Anti-Phishing phrase is either missing or incorrect, you may be the victim of phishing. You should immediately confirm that you are visiting ",
       "phishing_phrase_title": "Anti Phishing Phrase",


### PR DESCRIPTION
Fixes #1202 

### Changes description

- Added `Ask to use local cache` on the Settings/Security page.
- I made a new group `Local Storage` with  `Ask to use local cache`  and  `Using local/session storage` because they are related to each other.
