### PR TITLE
enhancement for reply, reply all logic

### DIFF
--- a/src/app/mail/mail-detail/mail-detail.component.ts
+++ b/src/app/mail/mail-detail/mail-detail.component.ts
@@ -847,48 +847,48 @@ export class MailDetailComponent implements OnInit, OnDestroy {
       let newReceivers = undefined;
       if (mainReply && mail.children?.length > 0) {
         // set reciever with it with the reciever and sender of latest child that is not on Trash
-          if (this.isShowTrashRelatedChildren) {
-            // Detect it's sent email from this account
-            if (this.mailboxes.some(mailbox => mail.children[mail.children.length - 1].sender === mailbox.email)) {
-              // If it is sent email from this account, will set all of emails would be set on the reciever without itself
-              newReceivers = new Set([
-                ...mail.children[mail.children.length - 1].receiver,
-                mail.children[mail.children.length - 1].sender,
-                ...mail.children[mail.children.length - 1].cc,
-                ...mail.children[mail.children.length - 1].bcc
-              ]);
-              newReceivers.delete(this.currentMailbox?.email);
-            } else {
-              // If it is received email from the other, only sender would be set as receiver
-              newReceivers = [mail.children[mail.children.length - 1].sender];
-            }
+        if (this.isShowTrashRelatedChildren) {
+          // Detect it's sent email from this account
+          if (this.mailboxes.some(mailbox => mail.children[mail.children.length - 1].sender === mailbox.email)) {
+            // If it is sent email from this account, will set all of emails would be set on the reciever without itself
+            newReceivers = new Set([
+              ...mail.children[mail.children.length - 1].receiver,
+              mail.children[mail.children.length - 1].sender,
+              ...mail.children[mail.children.length - 1].cc,
+              ...mail.children[mail.children.length - 1].bcc,
+            ]);
+            newReceivers.delete(this.currentMailbox?.email);
           } else {
-            for (let childIndex = mail.children.length; childIndex > 0; childIndex -= 1) {
-              if ((this.mailFolder === MailFolderType.TRASH && mail.children[childIndex - 1].folder === MailFolderType.TRASH) || (this.mailFolder !== MailFolderType.TRASH && mail.children[childIndex - 1].folder !== MailFolderType.TRASH)) {
-                if (this.mailboxes.some(mailbox => mail.children[childIndex - 1].sender === mailbox.email)) {
-                  newReceivers = new Set([
-                    ...mail.children[childIndex - 1].receiver,
-                    mail.children[childIndex - 1].sender,
-                    ...mail.children[childIndex - 1].cc,
-                    ...mail.children[childIndex - 1].bcc
-                  ]);
-                  newReceivers.delete(this.currentMailbox?.email);
-                  break;
-                } else {
-                  newReceivers = [mail.children[childIndex - 1].sender];
-                  break;
-                }
-              }
-            }  
+            // If it is received email from the other, only sender would be set as receiver
+            newReceivers = [mail.children[mail.children.length - 1].sender];
           }
+        } else {
+          for (let childIndex = mail.children.length; childIndex > 0; childIndex -= 1) {
+            if (
+              (this.mailFolder === MailFolderType.TRASH &&
+                mail.children[childIndex - 1].folder === MailFolderType.TRASH) ||
+              (this.mailFolder !== MailFolderType.TRASH &&
+                mail.children[childIndex - 1].folder !== MailFolderType.TRASH)
+            ) {
+              if (this.mailboxes.some(mailbox => mail.children[childIndex - 1].sender === mailbox.email)) {
+                newReceivers = new Set([
+                  ...mail.children[childIndex - 1].receiver,
+                  mail.children[childIndex - 1].sender,
+                  ...mail.children[childIndex - 1].cc,
+                  ...mail.children[childIndex - 1].bcc,
+                ]);
+                newReceivers.delete(this.currentMailbox?.email);
+                break;
+              } else {
+                newReceivers = [mail.children[childIndex - 1].sender];
+                break;
+              }
+            }
+          }
+        }
       } else {
         if (this.mailboxes.some(mailbox => mail.sender === mailbox.email)) {
-          newReceivers = new Set([
-            ...mail.receiver,
-            mail.sender,
-            ...mail.cc,
-            ...mail.bcc
-          ]);
+          newReceivers = new Set([...mail.receiver, mail.sender, ...mail.cc, ...mail.bcc]);
           newReceivers.delete(this.currentMailbox?.email);
         } else {
           newReceivers = [mail.sender];
@@ -938,35 +938,34 @@ export class MailDetailComponent implements OnInit, OnDestroy {
     let newReceivers = undefined;
     if (mainReply && mail.children?.length > 0) {
       // set reciever with it with the reciever and sender of latest child that is not on Trash
-        if (this.isShowTrashRelatedChildren) {
-          newReceivers = new Set([
-            ...mail.children[mail.children.length - 1].receiver,
-            mail.children[mail.children.length - 1].sender,
-            ...mail.children[mail.children.length - 1].cc,
-            ...mail.children[mail.children.length - 1].bcc
-          ]);
-          newReceivers.delete(this.currentMailbox?.email);
-        } else {
-          for (let childIndex = mail.children.length; childIndex > 0; childIndex -= 1) {
-            if ((this.mailFolder === MailFolderType.TRASH && mail.children[childIndex - 1].folder === MailFolderType.TRASH) || (this.mailFolder !== MailFolderType.TRASH && mail.children[childIndex - 1].folder !== MailFolderType.TRASH)) {
-              newReceivers = new Set([
-                ...mail.children[childIndex - 1].receiver,
-                mail.children[childIndex - 1].sender,
-                ...mail.children[childIndex - 1].cc,
-                ...mail.children[childIndex - 1].bcc
-              ]);
-              newReceivers.delete(this.currentMailbox?.email);
-              break;
-            }
-          }  
+      if (this.isShowTrashRelatedChildren) {
+        newReceivers = new Set([
+          ...mail.children[mail.children.length - 1].receiver,
+          mail.children[mail.children.length - 1].sender,
+          ...mail.children[mail.children.length - 1].cc,
+          ...mail.children[mail.children.length - 1].bcc,
+        ]);
+        newReceivers.delete(this.currentMailbox?.email);
+      } else {
+        for (let childIndex = mail.children.length; childIndex > 0; childIndex -= 1) {
+          if (
+            (this.mailFolder === MailFolderType.TRASH &&
+              mail.children[childIndex - 1].folder === MailFolderType.TRASH) ||
+            (this.mailFolder !== MailFolderType.TRASH && mail.children[childIndex - 1].folder !== MailFolderType.TRASH)
+          ) {
+            newReceivers = new Set([
+              ...mail.children[childIndex - 1].receiver,
+              mail.children[childIndex - 1].sender,
+              ...mail.children[childIndex - 1].cc,
+              ...mail.children[childIndex - 1].bcc,
+            ]);
+            newReceivers.delete(this.currentMailbox?.email);
+            break;
+          }
         }
+      }
     } else {
-      newReceivers = new Set([
-        ...mail.receiver,
-        mail.sender,
-        ...mail.cc,
-        ...mail.bcc
-      ]);
+      newReceivers = new Set([...mail.receiver, mail.sender, ...mail.cc, ...mail.bcc]);
       newReceivers.delete(this.currentMailbox?.email);
     }
     newMail.receiver = newReceivers ? [...newReceivers] : [];


### PR DESCRIPTION
Fixes #1328 

### Changes description
Updated Reply Logic for email thread same as how Gmail does
@The-Hidden-Hand , please correct me, if you think something goes wrong...

Let's say 3 emails in an email thread, `A` is Me, `B` and `C` are the others.
Reply logic would be done as following...
1. If the user try to reply for specific message (through dropdown button)
    * If this specific message's sender is `A`, will set `B` and `C` as receivers
    * If sender is `B` or `C`, will set `B` or `C` as receiver
2. If the user try to reply all for specific message (through dropdown button)
    it will set `B` and `C` as receivers without care what is sender of message
3. If the user try to reply or reply all on the bottom of thread
    It will take latest child and do same behavior as above.

