### PR TITLE
Improve UI for the advanced search - Datepicker auto close; ui fix

### DIFF
--- a/src/app/mail/mail-header/mail-header.component.scss
+++ b/src/app/mail/mail-header/mail-header.component.scss
@@ -238,7 +238,7 @@
 
   .search-input {
     border-radius: 0;
-    width: calc(100% - 32px); // to offset the width of .advanced-search-btn so that border focus is visible
+    width: calc(100% - 31px); // to offset the width of .advanced-search-btn so that border focus is visible
   }
 
   .search-btn {
@@ -262,6 +262,7 @@
       width: 30px;
       height: 32px;
       min-width: 30px;
+      border-left-width: 0;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
       &::before {

--- a/src/app/shared/components/advanced-search/advanced-search.component.html
+++ b/src/app/shared/components/advanced-search/advanced-search.component.html
@@ -179,6 +179,8 @@
         <ngb-datepicker
           #startDateDatePicker
           [(ngModel)]="startDate"
+          [skipFirst]="true"
+          (clickOutside)="isShowStartDate = false"
           *ngIf="isShowStartDate"
           [maxDate]="endDate ? endDate : calendar.getToday()"
           class="bg-white ng-datepicker ng-datepicker-265 advanced-search-date-picker position-absolute"
@@ -215,6 +217,8 @@
           #endDateDatePicker
           [(ngModel)]="endDate"
           *ngIf="isShowEndDate"
+          [skipFirst]="true"
+          (clickOutside)="isShowEndDate = false"
           [maxDate]="calendar.getToday()"
           [minDate]="startDate ? startDate : null"
           class="bg-white ng-datepicker ng-datepicker-265 advanced-search-date-picker position-absolute"

--- a/src/app/shared/directives/click-outside.directive.ts
+++ b/src/app/shared/directives/click-outside.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Output, EventEmitter, HostListener } from '@angular/core';
+import { Directive, ElementRef, Output, EventEmitter, HostListener, Input } from '@angular/core';
 
 @Directive({
   selector: '[clickOutside]',
@@ -6,8 +6,13 @@ import { Directive, ElementRef, Output, EventEmitter, HostListener } from '@angu
 export class ClickOutsideDirective {
   constructor(private elementReference: ElementRef) {}
 
+  @Input()
+  skipFirst = false;
+
   @Output()
   public clickOutside = new EventEmitter<MouseEvent>();
+
+  canEmit = false;
 
   @HostListener('document:click', ['$event', '$event.target'])
   public onClick(event: MouseEvent, targetElement: HTMLElement): void {
@@ -17,7 +22,14 @@ export class ClickOutsideDirective {
 
     const clickedInside = this.elementReference.nativeElement.contains(targetElement);
     if (!clickedInside) {
-      this.clickOutside.emit(event);
+      // #1477 in cases like datepicker where we rely on this directive to close popup,
+      // click outside is triggered as soon as the popup is opened and
+      // it closes immediately. we are skipping the first outside click 
+      // which is actually trigger that opened the popup
+      if (!this.skipFirst || this.canEmit) {
+        this.clickOutside.emit(event);
+      }
+      this.canEmit = true;
     }
   }
 }


### PR DESCRIPTION
1. Click outside closes calendar popup
2. There is a double border located in the search field located in the header

