### PR TITLE
Fix: Unable to open emails with Control + Click or Right Click (UPDATED)

### DIFF
--- a/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.html
+++ b/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.html
@@ -376,7 +376,7 @@
             <!-- Sender Name -->
             <td class="mail-from-name">
               <a
-                (click)="openMail(mail)"
+                [routerLink]="mail.mailLink"
                 class="text-danger display-emails"
                 [ngClass]="{ 'text-dark': mailFolder !== mailFolderTypes.DRAFT }"
               >
@@ -414,7 +414,7 @@
             </td>
             <!-- Subject -->
             <td class="mail-inbox-message d-md-block">
-              <a (click)="openMail(mail)" class="text-dark">
+              <a [routerLink]="mail.mailLink" class="text-dark">
                 <span class="mail-subject">
                   <ng-container *ngIf="mailFolder === mailFolderTypes.SENT || mailFolder === mailFolderTypes.INBOX">
                     <span class="badge badge-warning mr-2 p-1" *ngIf="mail.destruct_date">
@@ -582,7 +582,7 @@
             <td class="mail-from-name">
               <!-- Sender Name -->
               <a
-                (click)="openMail(mail)"
+                [routerLink]="mail.mailLink"
                 class="text-danger display-emails"
                 [ngClass]="{ 'text-dark': mailFolder !== mailFolderTypes.DRAFT }"
               >
@@ -607,7 +607,7 @@
                 <i *ngIf="mail.is_verified" class="fa fa-check-circle verified-sender"></i>
               </a>
               <span class="mail-inbox-message d-md-block">
-                <a (click)="openMail(mail)" class="text-dark">
+                <a [routerLink]="mail.mailLink" class="text-dark">
                   <span class="mail-subject">
                     <ng-container *ngIf="mailFolder === mailFolderTypes.SENT || mailFolder === mailFolderTypes.INBOX">
                       <span class="badge badge-warning mr-2 p-1" *ngIf="mail.destruct_date">

--- a/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.html
+++ b/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.html
@@ -376,6 +376,7 @@
             <!-- Sender Name -->
             <td class="mail-from-name">
               <a
+                (click)="openDraftMail(mail)"
                 [routerLink]="mail.mailLink"
                 class="text-danger display-emails"
                 [ngClass]="{ 'text-dark': mailFolder !== mailFolderTypes.DRAFT }"
@@ -414,7 +415,7 @@
             </td>
             <!-- Subject -->
             <td class="mail-inbox-message d-md-block">
-              <a [routerLink]="mail.mailLink" class="text-dark">
+              <a (click)="openDraftMail(mail)" [routerLink]="mail.mailLink" class="text-dark">
                 <span class="mail-subject">
                   <ng-container *ngIf="mailFolder === mailFolderTypes.SENT || mailFolder === mailFolderTypes.INBOX">
                     <span class="badge badge-warning mr-2 p-1" *ngIf="mail.destruct_date">
@@ -582,6 +583,7 @@
             <td class="mail-from-name">
               <!-- Sender Name -->
               <a
+                (click)="openDraftMail(mail)"
                 [routerLink]="mail.mailLink"
                 class="text-danger display-emails"
                 [ngClass]="{ 'text-dark': mailFolder !== mailFolderTypes.DRAFT }"
@@ -607,7 +609,7 @@
                 <i *ngIf="mail.is_verified" class="fa fa-check-circle verified-sender"></i>
               </a>
               <span class="mail-inbox-message d-md-block">
-                <a [routerLink]="mail.mailLink" class="text-dark">
+                <a (click)="openDraftMail(mail)" [routerLink]="mail.mailLink" class="text-dark">
                   <span class="mail-subject">
                     <ng-container *ngIf="mailFolder === mailFolderTypes.SENT || mailFolder === mailFolderTypes.INBOX">
                       <span class="badge badge-warning mr-2 p-1" *ngIf="mail.destruct_date">

--- a/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.ts
+++ b/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.ts
@@ -489,6 +489,15 @@ export class GenericFolderComponent implements OnInit, AfterViewInit {
     return `/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/${mail.id}`;
   }
 
+  openDraftMail(mail: Mail) {
+    if (this.mailFolder === MailFolderType.DRAFT && !mail.has_children) {
+      this.composeMailService.openComposeMailDialog({
+        draft: mail,
+        isFullScreen: this.userState.settings.is_composer_full_screen,
+      });
+    }
+  }
+
   /**
    * @description
    * Prime Users - Can create as many folders as they want

--- a/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.ts
+++ b/src/app/mail/mail-list/mail-folder/generic-folder/generic-folder.component.ts
@@ -131,7 +131,7 @@ export class GenericFolderComponent implements OnInit, AfterViewInit {
     private modalService: NgbModal,
     private translate: TranslateService,
     private keyManageService: KeyManageService,
-  ) {}
+  ) { }
 
   ngOnInit() {
     /**
@@ -145,7 +145,10 @@ export class GenericFolderComponent implements OnInit, AfterViewInit {
         this.showProgress = !mailState.loaded || mailState.inProgress;
         if (this.fetchMails) {
           this.MAX_EMAIL_PAGE_LIMIT = mailState.total_mail_count;
-          this.mails = [...mailState.mails];
+          this.mails = [...mailState.mails].map(mail => {
+            mail.mailLink = this.getMailLink(mail);
+            return mail;
+          });
           if (this.mails.length > 0) {
             this.getMailReceiverList();
           }
@@ -469,47 +472,21 @@ export class GenericFolderComponent implements OnInit, AfterViewInit {
     this.isDeleteDraftClicked = true;
   }
 
-  openMail(mail: Mail) {
+  // Unable to open emails with Control + Click or Right Click (UPDATED) #1323
+  /**
+   * @description Generates the mail deep link based on the current folder
+   * and this is added to routerlink which would handle ctrl+click, right-click->new tab, middle-click
+   * @param  {Mail} mail
+   * @returns string
+   */
+  getMailLink(mail: Mail): string {
     if (this.mailFolder === MailFolderType.DRAFT && !mail.has_children) {
-      this.composeMailService.openComposeMailDialog({
-        draft: mail,
-        isFullScreen: this.userState.settings.is_composer_full_screen,
-      });
-    } else {
-      const queryParameters: any = {};
-      if (this.mailFolder === MailFolderType.SEARCH) {
-        if (this.searchText) {
-          queryParameters.search = this.searchText;
-        }
-
-        if (this.isKeyDownCtrlBtn) {
-          window.open(
-            `/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/${mail.parent ? mail.parent : mail.id}`,
-            '_blank',
-          );
-        } else {
-          this.router.navigate(
-            [`/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/`, mail.parent ? mail.parent : mail.id],
-            {
-              queryParams: queryParameters,
-            },
-          );
-        }
-      } else {
-        if (this.isKeyDownCtrlBtn) {
-          if (this.userState?.settings?.auto_read) {
-            const ids = [mail.id].join(',');
-            this.store.dispatch(new ReadMail({ ids, read: true, folder: this.mailFolder }));
-          }
-          window.open(`/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/${mail.id}`, '_blank');
-        } else {
-          this.store.dispatch(new GetMailDetailSuccess(mail));
-          this.router.navigate([`/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/`, mail.id], {
-            queryParams: queryParameters,
-          });
-        }
-      }
+      return undefined;
     }
+    if (this.mailFolder === MailFolderType.SEARCH) {
+      return `/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/${mail.parent ? mail.parent : mail.id}`;
+    }
+    return `/mail/${this.mailFolder}/page/${this.PAGE + 1}/message/${mail.id}`;
   }
 
   /**

--- a/src/app/store/models/mail.model.ts
+++ b/src/app/store/models/mail.model.ts
@@ -59,6 +59,7 @@ export interface Mail {
   email_display_name_map?: any;
   sign?: string;
   participants?: any;
+  mailLink?: string; // set in UI for generating the mail's deep-link
 }
 
 export class EncryptionNonCTemplar {


### PR DESCRIPTION
Fixes #

It would be wonderful if we can get rid of javascript on this solution (so we can have native right-click + copy or whatever)

Mails now can be opened with Click, right-click -> new tab, middle click, ctrl+click

-
