### PR TITLE
Compose: No warning when sending a message without subject #1504

### DIFF
--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.html
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.html
@@ -232,6 +232,7 @@
           [(ngModel)]="mailData.subject"
           (ngModelChange)="valueChanged$.next(mailData.subject); onSubjectChange(mailData.subject)"
           id="subject"
+          #subjectInput
         />
       </div>
       <!-- 'Subject' field -->
@@ -1090,7 +1091,7 @@
       <h3 class="modal-title w-100 text-dark">
         <strong [translate]="'settings.compose.confirm_send'">Confirm Send </strong>
       </h3>
-      <button type="button" class="close" data-dismiss="modal" aria-label="Close" (click)="d()">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close" (click)="onCancelEmptyMailContentClick()">
         <span aria-hidden="true">&times;</span>
       </button>
     </div>
@@ -1102,7 +1103,7 @@
           >
         </div>
         <div class="form-group text-right mb-0">
-          <button (click)="d()" class="btn btn-secondary btn-sm mr-2" role="button">
+          <button (click)="onCancelEmptyMailContentClick()" class="btn btn-secondary btn-sm mr-2" role="button">
             <span [translate]="'common.cancel'">Cancel</span>
           </button>
           <button (click)="sendEmail()" class="btn btn-danger btn-sm" role="button" [disabled]="userState?.inProgress">

--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.ts
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.ts
@@ -130,6 +130,8 @@ export class ComposeMailComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @ViewChild('composerEditorElementRef', { read: ElementRef, static: false }) composerEditorElementRef: any;
 
+  @ViewChild('subjectInput') subjectInput: ElementRef;
+
   @ViewChild('attachmentHolder') attachmentHolder: any;
 
   @ViewChild('toolbar') toolbar: any;
@@ -1278,13 +1280,8 @@ export class ComposeMailComponent implements OnInit, AfterViewInit, OnDestroy {
       }, 100);
       return;
     }
-    if (
-      this.mailData.subject === '' &&
-      ((this.draftMail.is_html &&
-        this.getPlainText(this.composerEditorInstance?.getData()).replace(/ /g, '').replace(/\n/g, '').length === 0) ||
-        (!this.draftMail.is_html && this.mailData.content.replace(/ /g, '').replace(/\n/g, '').length === 0))
-    ) {
-      // show message to confirm without subject and content
+    // Check if the subject or body is empty and show a warning
+    if (this.isMailSubjectEmpty() || this.isMailBodyEmpty()) {
       this.confirmModalRef = this.modalService.open(this.confirmationModal, {
         centered: true,
         windowClass: 'modal-sm users-action-modal',
@@ -1294,6 +1291,25 @@ export class ComposeMailComponent implements OnInit, AfterViewInit, OnDestroy {
       //   this.addHyperLink();
       // }
       this.sendEmail();
+    }
+  }
+
+  isMailSubjectEmpty() {
+    return this.mailData.subject === '';
+  }
+
+  isMailBodyEmpty() {
+    const bodyLength = this.draftMail.is_html
+      ? this.getPlainText(this.composerEditorInstance?.getData()).replace(/ /g, '').replace(/\n/g, '').length
+      : this.mailData.content.replace(/ /g, '').replace(/\n/g, '').length;
+    return bodyLength === 0;
+  }
+
+  onCancelEmptyMailContentClick() {
+    this.confirmModalRef?.dismiss();
+    this.isPreparingToSendEmail = false;
+    if (this.isMailSubjectEmpty()) {
+      setTimeout(() => this.subjectInput?.nativeElement?.focus());
     }
   }
 


### PR DESCRIPTION
Fixes #

-Show empty content warning when subject or body is empty
-When cancel is clicked go back to mail
-When cancel clicked and subject is empty, move focus to subject
-Fix for send button disabled when modal is closed
