### PR TITLE
Replies add myself as recipient in these two cases and it should not #1461

### DIFF
--- a/src/app/mail/mail-detail/mail-detail.component.ts
+++ b/src/app/mail/mail-detail/mail-detail.component.ts
@@ -892,6 +892,14 @@ export class MailDetailComponent implements OnInit, OnDestroy {
           }
         } else {
           for (let childIndex = mail.children.length; childIndex > 0; childIndex -= 1) {
+            // Skip draft mails while going up the thread until a mail is found
+            // Replies add myself as recipient in these two cases and it should not #1461
+            if (
+              this.mailFolder !== MailFolderType.DRAFT &&
+              mail.children[childIndex - 1].folder === MailFolderType.DRAFT
+            ) {
+              continue;
+            }
             if (
               (this.mailFolder === MailFolderType.TRASH &&
                 mail.children[childIndex - 1].folder === MailFolderType.TRASH) ||


### PR DESCRIPTION
Fixes 

-Global reply button always continues the thread
-It will reply to the last real message (not draft)
-If I reply to the thread using a third alias, and then reply again, it is fine the To address is my third alias (the last participant on the thread)