### PR TITLE
Can't see attachment on email received. #398

### DIFF
--- a/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.html
+++ b/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.html
@@ -155,7 +155,7 @@
       <!-- Attachments list starts -->
       <ul class="list-style-none mt-3 attachment-content" *ngIf="decryptedContents && mail?.attachments?.length > 0">
         <ng-container *ngFor="let attachment of mail?.attachments">
-          <li class="download-attachment-wrapper mr-1" *ngIf="!attachment.is_inline">
+          <li class="download-attachment-wrapper mr-1" *ngIf="!attachment.is_inline || !mail.is_html">
             <app-progress-bar [active]="decryptedAttachments[attachment.id]?.inProgress"></app-progress-bar>
             <a
               *ngIf="!attachment.is_encrypted; else encryptedAttachment"

--- a/src/app/users/display-secure-message/display-secure-message.component.html
+++ b/src/app/users/display-secure-message/display-secure-message.component.html
@@ -44,7 +44,7 @@
           <div>
             <ul class="list-style-none mt-3">
               <ng-container *ngFor="let attachment of message.attachments">
-                <li class="download-attachment-wrapper mr-1" *ngIf="!attachment.is_inline">
+                <li class="download-attachment-wrapper mr-1" *ngIf="!attachment.is_inline || !mail.is_html">
                   <app-progress-bar [active]="decryptedAttachments[attachment.id]?.inProgress"></app-progress-bar>
                   <a
                     *ngIf="!attachment.is_encrypted; else encryptedAttachment"


### PR DESCRIPTION
Fixes 

- display inline attachment in footer if email is plaintext
