### PR TITLE
Expirated messages should be DELETED timely by the backend #385

### DIFF
--- a/src/app/users/decrypt/decrypt-message.component.ts
+++ b/src/app/users/decrypt/decrypt-message.component.ts
@@ -3,7 +3,8 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, timer } from 'rxjs';
+import { filter, takeWhile, tap } from 'rxjs/operators';
 
 import { GetMessage } from '../../store/actions';
 import { AppState, SecureContent, SecureMessageState } from '../../store/datatypes';
@@ -47,6 +48,8 @@ export class DecryptMessageComponent implements OnInit, OnDestroy {
 
   password = '';
 
+  expiryDurationInSeconds: number;
+
   constructor(
     private route: ActivatedRoute,
     private store: Store<AppState>,
@@ -84,6 +87,7 @@ export class DecryptMessageComponent implements OnInit, OnDestroy {
           this.isMessageExpired = true;
         }
 
+        this.startExpiryTimer(state);
         this.message$.next(state.message);
         if (state.decryptedContent) {
           if (state.decryptedContent.content) {
@@ -95,6 +99,28 @@ export class DecryptMessageComponent implements OnInit, OnDestroy {
           }
         }
       });
+  }
+
+  startExpiryTimer(state: SecureMessageState) {
+    if (!this.message$.value && state.message) {
+      let expiryDurationInSeconds = this.dateTimeUtilService.getDiffFromCurrentDateTime(
+        state.message.encryption.expires,
+        'seconds',
+      );
+      timer(0, 1000) // start a 1 second interval timer
+        .pipe(
+          untilDestroyed(this),
+          takeWhile(() => expiryDurationInSeconds > 0 && !this.decryptedContent), // countdown to zero or right password entered
+          tap(() => {
+            expiryDurationInSeconds -= 1;
+          }),
+          filter(() => expiryDurationInSeconds === 0),
+        )
+        .subscribe(() => {
+          // when timer reached zero
+          this.isMessageExpired = true;
+        });
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/users/display-secure-message/display-secure-message.component.html
+++ b/src/app/users/display-secure-message/display-secure-message.component.html
@@ -3,7 +3,7 @@
     <div class="ui-card-header bg-primary text-sm-center">
       <h6 class="ui-card-title mb-0 fw-light text-white pr-4 px-sm-0" [translate]="'encryption.expiring_in'">
         Expiring in
-        <strong>
+        <strong class="pl-1">
           <app-countdown-timer [duration]="expiryDurationInSeconds" (finished)="onExpired()"></app-countdown-timer>
         </strong>
       </h6>


### PR DESCRIPTION
Fixes #

- start client timer before message is decrypted ( I used my ctemplar email send to my gmail with 1 hour expiration time. Then, I click on ‘view secure message’ on my gmail , but I don't type in password or anything. I just leave it there. I can leave it for a day or two. The email should expired in an hour time cos I set it 1 hour only, but no. I can still open that email after a day!)

-
