### PR TITLE
Composition Window (fix so there is no space after subject. #404

### DIFF
--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.scss
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.scss
@@ -133,3 +133,7 @@ textarea:disabled {
 ::ng-deep pre {
   overflow: hidden !important;
 }
+
+.mail-label {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Fixes #

- prevent wrap of compose-mail field labels
