### PR TITLE
Add an option to hide the menu bar in the Electron app #1521

### DIFF
--- a/electron-main.ts
+++ b/electron-main.ts
@@ -51,6 +51,7 @@ function createWindow() {
     y: mainWindowState.y,
     width: mainWindowState.width,
     height: mainWindowState.height,
+    autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true,
       allowRunningInsecureContent: serve ? true : false,


### PR DESCRIPTION
Fixes #

- toggle menu bar using alt key
