### PR TITLE
Keep font color black and bg white for mail content/compose for all themes

### DIFF
--- a/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.html
+++ b/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.html
@@ -116,7 +116,7 @@
           <div *ngIf="plainTextViewState; then plainBlock; else htmlBlock"></div>
           <ng-template #htmlBlock>
             <div
-              class="msg-reply-content text-dark"
+              class="msg-reply-content"
               [style.white-space]="isDecryptingError ? 'break-spaces' : ''"
               id="{{ mail?.id }}-raw-mail-content"
               [innerHTML]="
@@ -128,7 +128,7 @@
           </ng-template>
           <ng-template #plainBlock>
             <div
-              class="msg-reply-content text-dark"
+              class="msg-reply-content"
               id="{{ mail?.id }}-raw-mail-content"
               [innerHTML]="decryptedContentsPlain | linebreaktobrtag | safe: 'sanitize':disableExternalImages"
               [ngStyle]="{ 'font-family': plainTextFont ? plainTextFont : 'monospace' }"

--- a/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.scss
+++ b/src/app/mail/mail-detail/mail-detail-body/mail-detail-body.component.scss
@@ -1,5 +1,8 @@
 .mail-content {
   position: relative;
+  color: var(--text-color-mail-content);
+  background: var(--bg-color-mail-content);
+  margin: 0.3rem;
 
   .msg-reply-dropdown {
     position: absolute;

--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.scss
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.scss
@@ -19,8 +19,8 @@
   padding: 12px 15px;
   resize: none;
   font-size: 14px;
-  background-color: var(--bg-white);
-  color: var(--text-color-black-white);
+  background-color: var(--bg-color-mail-content);
+  color: var(--text-color-mail-content);
 }
 
 textarea:disabled {

--- a/src/styles/_theme-variables-collection.scss
+++ b/src/styles/_theme-variables-collection.scss
@@ -10,6 +10,8 @@ $width-3: 3px;
 $variables: (
   // General
   --text-color-black-white: (#000, #fff),
+  --text-color-mail-content: (#000, #000),
+  --bg-color-mail-content: (#fff, #fff),
   --brand-secondary: ($brand-secondary, $brand-secondary-dark),
   --text-color: ($text-color, $text-color-dark),
   --text-color-inverse: ($text-color-dark, $text-color),

--- a/src/styles/modules/mail-composer/_mail-composer.scss
+++ b/src/styles/modules/mail-composer/_mail-composer.scss
@@ -357,7 +357,7 @@ a {
 }
 
 .mail-compose-editable-box {
-  background: var(--bg-white);
+  background: var(--bg-color-mail-content);
 
   &[contenteditable]:focus {
     outline: 0;
@@ -370,7 +370,8 @@ a {
   .ql-editor {
     min-height: 385.867px;
     line-height: inherit;
-    color: var(--text-color-black-white);
+    color: var(--text-color-mail-content);
+    background: var(--bg-color-mail-content);
 
     blockquote,
     .blockquote {
@@ -864,7 +865,8 @@ a {
 
 .ck-content {
   font-size: 14px;
-  color: var(--text-color-black-white);
+  color: var(--text-color-mail-content);
+  background: var(--bg-color-mail-content);
   p {
     margin-bottom: 0;
   }


### PR DESCRIPTION
Fixes #

- Keep font color black and bg white for mail content/compose for all themes
